### PR TITLE
Update postgresql node client driver

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "help-esb": "^0.4.1",
     "jshint-stylish": "^1.0.0",
     "knex": "^0.7.3",
-    "pg": "^4.0.0",
+    "pg": "^4.1.1",
     "underscore": "^1.7.0",
     "underscore.string": "^2.4.0",
     "uuid": "^2.0.1"


### PR DESCRIPTION
Update postgresql node client driver to version 4.1.1 to support pg 9.4